### PR TITLE
Added proxy commands onto the TO_PROXY list

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -13,7 +13,19 @@ import AndroidDriver from 'appium-android-driver';
 // Add commands from mobile-json-wire-protocol/lib/routes.js that should be mapped to existing drivers
 const TO_PROXY = [
   'getLog',
-  'getLogTypes'
+  'getLogTypes',
+  'closeApp',
+  'launchApp',
+  'getStrings',
+  'mobileShake',
+  'lock',
+  'unlock',
+  'isLocked',
+  'toggleFlightMode',
+  'toggleData',
+  'toggleWiFi',
+  'toggleLocationServices',
+  'background'
 ];
 
 class YouiDriver extends BaseDriver {
@@ -46,9 +58,10 @@ class YouiDriver extends BaseDriver {
 
     // setup proxies - if youiAppPlatform is not empty, make it less case sensitive
     if (this.opts.youiAppPlatform != null) {
-      if (this.opts.youiAppPlatform.toLowerCase() == "ios") {
+      let appPlatform = this.opts.youiAppPlatform.toLowerCase();
+      if (appPlatform == "ios") {
         await this.startIOSSession();
-      } else if (this.opts.youiAppPlatform.toLowerCase() == "android") {
+      } else if (appPlatform == "android") {
         await this.startAndroidSession();
       }
     }


### PR DESCRIPTION
Added a series of potentially proxiable commands.

**Non-Platform Specific**:
-   'closeApp' = driver.closeApp();
-   'launchApp' = driver.launchApp();
-   'getStrings' = driver.getAppStringMap();
-   'toggleLocationServices' = driver.toggleLocationServices(); (appears to be Android only)
-   'background = driver.runAppInBackground(10);

**Special**:
-   'lock' = android only: driver.lock();
  -- ios implements a 'lock' command, but it takes a number of seconds to remain locked for and automatically unlocks after that time. call: driver.lockFor(seconds);

**Android Only**:
-   'unlock' = driver.unlock();
-   'isLocked' = driver.isLocked();
-   'toggleFlightMode' = driver.toggleFlightMode();
  _NOTE: there was a comment in the appium-android-driver/lib/commands/network.js that suggests this will fail on real devices._
-   'toggleData' = driver.toggleData();
-   'toggleWiFi' = driver.toggleWiFi();

**iOS Only**:
-   'mobileShake' = driver.mobileShake();
