### PR TITLE
Fixed incorrect import of the errors module

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -1,5 +1,5 @@
 import logger from '../logger';
-import { errors } from 'appium-base-driver';
+import { errors } from 'mobile-json-wire-protocol';
 import { youiEngineDriverReturnValues } from '../utils';
 
 let commands = {};

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -3,7 +3,7 @@ import desiredCapConstraints from './desired-caps';
 import logger from './logger';
 import commands from './commands/index';
 import _ from 'lodash';
-import { errors } from 'appium-base-driver';
+import { errors } from 'mobile-json-wire-protocol';
 import B from 'bluebird';
 import { sleep } from 'asyncbox';
 


### PR DESCRIPTION
The `errors` module was being imported from `appium-base-driver`, however it should have been from `mobile-json-wire-protocol`. Node.js only validates that the source of the import is correct and not the actual module. As a result, there was a cascading error when an ElementNotFound error occurred during a `wait_until` loop.