### PR TITLE
US-3473 Appium client now throws correct exceptions

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -1,4 +1,4 @@
-import { errors } from 'appium-base-driver';
+import { errors } from 'mobile-json-wire-protocol';
 import _ from 'lodash';
 import log from '../logger';
 

--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -1,5 +1,5 @@
 import logger from '../logger';
-import { errors } from 'appium-base-driver';
+import { errors } from 'mobile-json-wire-protocol';
 import { unwrapEl } from '../utils';
 import { youiEngineDriverReturnValues } from '../utils';
 import { util } from 'appium-support';

--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -1,5 +1,5 @@
 import logger from '../logger';
-import { errors } from 'appium-base-driver';
+import { errors } from 'mobile-json-wire-protocol';
 import { youiEngineDriverReturnValues } from '../utils';
 
 let commands = {};

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,4 +1,4 @@
-import { errors } from 'appium-base-driver';
+import { errors } from 'mobile-json-wire-protocol';
 import _ from 'lodash';
 import log from '../logger';
 

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -1,4 +1,4 @@
-import { errors } from 'appium-base-driver';
+import { errors } from 'mobile-json-wire-protocol';
 import { unwrapEl } from '../utils';
 import { youiEngineDriverReturnValues } from '../utils';
 

--- a/lib/commands/screenshot.js
+++ b/lib/commands/screenshot.js
@@ -1,5 +1,5 @@
 import logger from '../logger';
-import { errors } from 'appium-base-driver';
+import { errors } from 'mobile-json-wire-protocol';
 
 let commands = {};
 


### PR DESCRIPTION
We needed to import the errors constant from the mobile-json-wire-protocol
file rather than the appium-base-driver file.