### PR TITLE
US-3502 Adjusted findElorEls command to use implicitWait in basedriver

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { errors } from 'appium-base-driver';
 import { youiEngineDriverReturnValues } from '../utils';
 
@@ -34,23 +35,39 @@ commands.findElOrEls = async function (strategy, selector, mult, context) {
     return JSON.stringify(commandObject);
   };
 
-  let findByAxIdCmd = createGetElementCommand(strategy, selector, mult, context);
-
-  let data = await this.executeSocketCommand(findByAxIdCmd);
-
   let result;
+  let doFind = async () => {
+    let findByAxIdCmd = createGetElementCommand(strategy, selector, mult, context);
+  
+    let res = await this.executeSocketCommand(findByAxIdCmd);
+
+    try {
+      result = JSON.parse(res);
+    } catch (e) {
+      // parse error
+      throw new Error("Bad response from findElOrEls");
+    }
+
+    // looks like we have to check the status or resulting value to see that it's not empty.
+    if (result.value === "")
+    {
+      return false;
+    }
+    return true;
+  };
+
   try {
-    result = JSON.parse(data);
-  } catch (e) {
-    throw new Error("Bad response from findElOrEls");
+    await this.implicitWaitForCondition(doFind);    
+  } catch (err) {
+    if (err.message && err.message.match(/Condition unmet/)){
+      // condition was not met, throw NoSuchElementError
+      throw new errors.NoSuchElementError();
+    } else {
+      // some other issue occurred, report it
+      throw err;
+    }
   }
-
-  // get status returned
-  if (result.status === youiEngineDriverReturnValues.WEBDRIVER_NO_SUCH_ELEMENT)
-    throw new errors.NoSuchElementError();
-
-
   return result.value;
-
 };
+
 export default commands;

--- a/lib/commands/timeout.js
+++ b/lib/commands/timeout.js
@@ -43,19 +43,6 @@ helpers.startNewCommandTimeout = function (cmd) {
     });
 };
 
-helpers.implicitWaitForCondition = async function (condFn) {
-  log.debug(`Waiting up to ${this.implicitWaitMs} ms for condition`);
-  let wrappedCondFn = async function (...args) {
-    // reset command timeout
-    this.clearNewCommandTimeout();
-
-    return await condFn(...args);
-  }.bind(this); // TODO: fix jshint and use an arrow function
-  return await waitForCondition(wrappedCondFn, {
-    waitMs: this.implicitWaitMs, intervalMs: 500, logger: log
-  });
-};
-
 Object.assign(extensions, commands, helpers);
 export { commands, helpers };
 export default extensions;


### PR DESCRIPTION
### Changes
- removed `helpers.implicitWaitForCondition` in our `timeout.js` so we fall through the the one defined in `appium-base-driver` like iOS does.
- adjusted code in the `commands.findElOrEls` in our `find.js` so we call the command and it returns a true/false so the `implicitWaitForCondition` will work correctly.

**Note**: use `set_wait(30)` in ARC to turn on implicit wait.

### Tested Scenarios
- [x] find single
- [x] find multiple
- [x] fail find single
- [x] fail find multiple
- [x] fail find single, but find during wait
- [x] fail find multiple, but find during wait

**Note**: only tested on iOS simulator, but since the execution is at the server/driver layer, it isn't device specific.

### To Do
- add tests for this in the java_client