### PR TITLE
US-3491 Added socket state check and reconnect

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -280,6 +280,11 @@ class YouiEngineDriver extends BaseDriver {
   // responses to the commands are BINARY
   async executeSocketCommand (cmd) {
 
+    if (!this.socket.writable) {
+      logger.info("Socket is not writable. Trying to reconnect.");
+      await this.connectSocket();
+    }
+
     let cmdPromise = new B((resolve) => {
       logger.debug('COMMAND: ' + cmd);
 


### PR DESCRIPTION
Since the socket server is in the Android activity the disconnection is
the expected behavior. When the activity returns to the foreground the
socket server is available again.

This change introduces a check on the socket writability in the execute
socked command function. If the socket is not writable we will attempt
to reconnect before issuing the command.