### PR TITLE
US-5457 Fixed proxied caps to allow support for all caps

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -79,12 +79,12 @@ class YouiEngineDriver extends BaseDriver {
       let [sessionId] = await super.createSession(caps);
 
       // setup proxies - if platformName is not empty, make it less case sensitive
-      if (this.opts.platformName !== null) {
-        let appPlatform = this.opts.platformName.toLowerCase();
+      if (caps.platformName !== null) {
+        let appPlatform = caps.platformName.toLowerCase();
         if (appPlatform === "ios") {
-          await this.startIOSSession();
+          await this.startIOSSession(caps);
         } else if (appPlatform === "android") {
-          await this.startAndroidSession();
+          await this.startAndroidSession(caps);
         }
       }
 
@@ -182,78 +182,53 @@ class YouiEngineDriver extends BaseDriver {
     return true;
   }
 
-  async setupNewIOSDriver (opts) {
+  async setupNewIOSDriver (caps) {
     let iosArgs = {
       javascriptEnabled: true,
     };
 
     let iosdriver = new IOSDriver(iosArgs);
     // If iOS version is 10 or above we need to use XCUITestDriver (and Xcode 8+)
-    if (opts.platformVersion) {
-      let majorVer = opts.platformVersion.toString().split(".")[0];
+    if (caps.platformVersion) {
+      let majorVer = caps.platformVersion.toString().split(".")[0];
       if (parseInt(majorVer, 10) >= 10) {
         iosdriver = new XCUITestDriver(iosArgs);
       }
     }
-
-    let caps = {
-      platformName: "iOS",
-      browserName: "",
-      app: opts.app,
-      udid: opts.udid,
-      platformVersion: opts.platformVersion,
-      deviceName: opts.deviceName,
-      //XCUITest specific (no harm in sending them to IOSDriver)
-      noReset: opts.noReset,
-      processArguments: opts.processArguments,
-      wdaLocalPort: opts.wdaLocalPort,
-      showXcodeLog: opts.showXcodeLog,
-      realDeviceLogger: opts.realDeviceLogger,
-      iosInstallPause: opts.iosInstallPause,
-      xcodeConfigFile: opts.xcodeConfigFile,
-      // Disabling the proxy CommandTimeout in the iOS driver since we are now handling it in the YouiEngine Driver
-      newCommandTimeout: 0
-    };
-    await iosdriver.createSession(caps);
+    let capsCopy = _.cloneDeep(caps);
+    // Disabling the proxy CommandTimeout in the iOS driver since we are now handling it in the YouiEngine Driver
+    capsCopy.newCommandTimeout =  0
+    await iosdriver.createSession(capsCopy);
 
     return iosdriver;
   }
 
-  async startIOSSession () {
+  async startIOSSession (caps) {
     logger.info("Starting an IOS proxy session");
     this.proxyAllowList = TO_PROXY_IOS;
-    let opts = _.cloneDeep(this.opts);
-
-    this.proxydriver = await this.setupNewIOSDriver(opts);
+    
+    this.proxydriver = await this.setupNewIOSDriver(caps);
   }
 
-  async setupNewAndroidDriver (opts) {
+  async setupNewAndroidDriver (caps) {
     let androidArgs = {
       javascriptEnabled: true
     };
     let androiddriver = new AndroidDriver(androidArgs);
+    let capsCopy = _.cloneDeep(caps);
+    // Disabling the proxy CommandTimeout in the Android driver since we are now handling it in the YouiEngine Driver
+    capsCopy.newCommandTimeout = 0
 
-    let caps = {
-      platformName: "android",
-      browserName: "",
-      app: this.caps.app,
-      platformVersion: opts.platformVersion,
-      deviceName: opts.deviceName,
-      avd: this.caps.avd,
-      // Disabling the proxy CommandTimeout in the Android driver since we are now handling it in the YouiEngine Driver
-      newCommandTimeout: 0
-    };
-    await androiddriver.createSession(caps);
+    await androiddriver.createSession(capsCopy);
 
     return androiddriver;
   }
 
-  async startAndroidSession () {
+  async startAndroidSession (caps) {
     logger.info("Starting an Android proxy session");
     this.proxyAllowList = TO_PROXY_ANDROID;
-    let opts = _.cloneDeep(this.opts);
-
-    this.proxydriver = await this.setupNewAndroidDriver(opts);
+    
+    this.proxydriver = await this.setupNewAndroidDriver(caps);
   }
 
 // SOCKETS

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "appium"
   ],
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": "youi.tv",
   "license": "Apache-2.0",
   "repository": {
@@ -20,15 +20,15 @@
     "lib": "lib"
   },
   "dependencies": {
-    "appium-android-driver": "1.10.31",
-    "appium-base-driver": "^2.0.23",
-    "appium-ios-driver": "^1.12.31",
-    "appium-support": "^2.5.0",
-    "appium-xcuitest-driver": "^2.0.34",
-    "asyncbox": "^2.3.1",
+    "appium-android-driver": "1.x",
+    "appium-base-driver": "2.x",
+    "appium-ios-driver": "1.x",
+    "appium-support": "2.x",
+    "appium-xcuitest-driver": "2.x",
+    "asyncbox": "2.x",
     "babel-runtime": "=5.8.24",
-    "bluebird": "^2.10.2",
-    "lodash": "^4.16.6"
+    "bluebird": "2.x",
+    "lodash": "4.x"
   },
   "scripts": {
     "prepublish": "gulp prepublish",
@@ -36,18 +36,18 @@
     "watch": "gulp"
   },
   "devDependencies": {
-    "appium-gulp-plugins": "^1.4.5",
-    "appium-test-support": "0.0.5",
-    "babel-eslint": "^6.1.2",
-    "chai": "^3.5.0",
-    "chai-as-promised": "^5.3.0",
-    "eslint": "^2.13.1",
-    "eslint-config-appium": "0.0.6",
-    "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-import": "^1.12.0",
-    "eslint-plugin-mocha": "^3.0.0",
-    "gulp": "^3.9.1",
-    "sample-apps": "^2.0.4",
-    "sinon": "^1.17.5"
+    "appium-gulp-plugins": "1.x",
+    "appium-test-support": "0.x",
+    "babel-eslint": "6.x",
+    "chai": "3.x",
+    "chai-as-promised": "5.x",
+    "eslint": "2.x",
+    "eslint-config-appium": "0.x",
+    "eslint-plugin-babel": "3.x",
+    "eslint-plugin-import": "1.x",
+    "eslint-plugin-mocha": "3.x",
+    "gulp": "3.x",
+    "sample-apps": "2.x",
+    "sinon": "1.x"
   }
 }


### PR DESCRIPTION
Problem:
We currently manually create all caps of interest before passing them to a proxied driver.
If the driver supports new caps, we need to modify our driver to add them.

Solution:
This change will avoid having to modify the driver as it will just pass the caps the user has defined.
The following warning will now appear in the proxied driver:
"The following capabilities were provided, but are not recognized by appium: youiEngineAppAddress."
This doesn't cause any problem.