### PR TITLE
US-8779 Added ability to install/launch on tvOS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Java and Ruby based test client scripts and applications can used to automate te
 | `name`                         |
 | `id`                           |
 | `class name`                   |
+| `accessibility id`             |
 
 
 

--- a/docs/SupportedCommands/Commands.md
+++ b/docs/SupportedCommands/Commands.md
@@ -27,10 +27,13 @@
 | `move`	                 | 					4.2.7+	 				|
 | `removeApp`                | 					4.2.1+	 				|
 | `setValue`                 | 					4.2.1+	 				|
+| `setValue (1)`                 | 					5.0.0+	 				|
 | `startNewCommandTimeout`   | 					4.2.1+	 				|
 | `timeouts`                 | 					4.2.1+	 				|
 | `up`		                 | 					4.2.7+	 				|
 | `updateSettings`           | 					4.2.5+	 				|
+
+(1) Calling setValue from root element will trigger a general sendkeys
 
 | Proxied Command (iOS, Android)    |
 |-----------------------------------|

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -7,6 +7,7 @@ const desiredCapConstraints = {
       'Android',
       'Mac',
       'YIMac',
+      'YItvOS',
       'NoProxy',
     ]
   },

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -91,6 +91,8 @@ class YouiEngineDriver extends BaseDriver {
           await this.startMacSession(caps);
         } else if (appPlatform === "yimac") {
           this.startYIMacSession(caps);
+        } else if (appPlatform === "yitvos") {
+          this.startYITVOSSession(caps);
         }
       }
 
@@ -117,6 +119,16 @@ class YouiEngineDriver extends BaseDriver {
 
   async deleteSession () {
     logger.debug("Deleting YouiEngine session");
+    
+    if (this.caps.platformName !== null) {
+      let appPlatform = this.caps.platformName.toLowerCase();
+      if (appPlatform === "yimac") {
+        this.endYIMacSession(this.caps);
+      } else if (appPlatform === "yitvos") {
+        this.endYITVOSSession(this.caps);
+      }
+    }
+    
     if (this.proxydriver !== null) {
       await this.proxydriver.deleteSession();
     }
@@ -266,8 +278,7 @@ class YouiEngineDriver extends BaseDriver {
     this.proxydriver = await this.setupNewMacDriver(caps);
   }
   
-  startYIMacSession (caps) {  
-    
+  startYIMacSession (caps) {    
     logger.info("Killing app if run");
     var shell = require('shelljs');
     var process_name = caps.app.substring(caps.app.lastIndexOf("/") + 1);
@@ -276,6 +287,31 @@ class YouiEngineDriver extends BaseDriver {
     logger.info("Launching app");
     var child_process = require('child_process'); 
     child_process.exec(caps.app);
+  }
+
+  endYIMacSession (caps) {
+    logger.info("Deleting app");
+    var shell = require('shelljs');
+    var process_name = caps.app.substring(caps.app.lastIndexOf("/") + 1);
+    shell.exec("killall " + process_name);
+  }
+  
+  startYITVOSSession (caps) {  
+    logger.info("Launching app");
+    var shell = require('shelljs');
+    shell.exec("ios-deploy --id " + caps.udid + " --uninstall --justlaunch --bundle " + caps.app);
+  }
+  
+  endYITVOSSession (caps) {
+    // If multiple apps with our socket are installed, it will connect to the first app installed.
+    // For this reason, every app should be uninstalled after running.
+    // If a bundleId is defined in the caps, that app will be deleted at the end of the session.
+    if (caps.bundleId)
+    {
+      logger.info("Deleting app");
+      var shell = require('shelljs');
+      shell.exec("ios-deploy --id " + caps.udid + " --uninstall_only --bundle_id " + caps.bundleId);
+    }
   }
 
 // SOCKETS


### PR DESCRIPTION
This change will allow the install/launch on tvOS of app provided in caps.
If `bundleId` is provided in caps, the app will be deleted upon deleting the session.
Only works for wired tvOS (not Apple 4k).
On Apple 4k, the app will install but not launch.

Also added deletion of macOS app upon deleting the session.
Also added extra documentation.