### PR TITLE
PA-88 Modified default sourceTree to be generated with displayed elements only.

### DIFF
--- a/lib/commands/settings.js
+++ b/lib/commands/settings.js
@@ -68,7 +68,7 @@ commands.setSourceTreeFilter = async function (filter) {
     throw new errors.UnknownCommandError('argument must be numeric and larger than zero');
   }
   if (result.status === youiEngineDriverReturnValues.WEBDRIVER_INVALID_SELECTOR) {
-    throw new errors.InvalidSelectorError("Attribute filter should have following format: [@attributeType='attributeValue']");
+    throw new errors.InvalidSelectorError("Attribute filter should have following format: [@attributeType='attributeValue'] or '' to reset. ('' is supported in You.i Engine 5.3+)");
   }
   return result.value;
 };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -125,6 +125,13 @@ class YouiEngineDriver extends BaseDriver {
       }
 
       await this.connectSocket();
+
+      if (caps.fullSourceTree === true) {
+        //Do not set filter
+      } else {
+        await this.updateSettings({SourceTreeFilter: "[@isDisplayed='true']"});
+      }
+
       return [sessionId, this.opts];
 
     } catch (e) {


### PR DESCRIPTION
To have the full sourceTree, use the following caps:
fullSourceTree = true
Having this as the default state will help eliminate clutter when multiple screens are loaded in parallel.
It will also allow Appium Desktop to highlight elements properly, as it would previously get confused if multiple screen were loaded in parallel and elements would share the same coordinates.