### PR TITLE
chore: update appium-base-driver to 4.0.0

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { errors, BaseDriver } from 'appium-base-driver';
+import { errors, PROTOCOLS } from 'appium-base-driver';
 import logger from '../logger';
 
 let extensions = {};
@@ -13,7 +13,7 @@ extensions.execute = async function execute (script, args) {
   if (!this.isWebContext()) {
     throw new errors.NotImplementedError();
   }
-  const endpoint = this.chromedriver.jwproxy.downstreamProtocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP
+  const endpoint = this.chromedriver.jwproxy.downstreamProtocol === PROTOCOLS.MJSONWP
     ? '/execute'
     : '/execute/sync';
   return await this.chromedriver.jwproxy.command(endpoint, 'POST', {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-android-driver": "^4.0.0",
-    "appium-base-driver": "^3.x",
+    "appium-base-driver": "^4.x",
     "appium-ios-driver": "^4.3.0",
     "appium-ios-simulator": "3.x",
     "appium-mac-driver": "1.x",


### PR DESCRIPTION
The `appium-base-driver` package has been updated with breaking changes.

This PR supports:
* https://github.com/appium/appium-base-driver/pull/346
* https://github.com/appium/appium-base-driver/pull/350