### PR TITLE
BS-893 added xcuitest support for tvos

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ Support added in 5.0+
 | udid                 | `<device’s udid>`       |
 | youiEngineAppAddress | `<device’s IP address>` |
 
+#### tvOS
+Support added in 5.0+
+<sup>\*</sup> If another app is installed with You.i's socket, it may connect to it. All You.i apps should be deleted before running Appium.
+
+| Capability           | Simulator                     | Real device             |
+|----------------------|-------------------------------|-------------------------|
+| app                  | `<path to the app>`           | `<path to the app>`     |
+| automationName       | `YouiEngine`                  | `YouiEngine`            |
+| deviceName           | `<tvOS Simulator device name>` | `<device’s name>`       |
+| platformName         | `tvos`                         | `tvos`                   |
+| udid                 | `<device’s udid>`             | `<device’s udid>`       |
+| xcodeOrgId           | `<Team ID>`                   | `<Team ID>`             |
+| youiEngineAppAddress | `localhost`                   | `<device’s IP address>` |
+
 
 #### BlueSky
 Support added in 5.0+

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -90,8 +90,9 @@ class YouiEngineDriver extends BaseDriver {
         let appPlatform = caps.platformName.toLowerCase();
         switch (appPlatform) {
           case 'ios':
-            await this.startIOSSession(caps);
-            break;
+          case 'tvos': 
+            await this.startXCUITestSession(caps);
+            break;      
           case 'android':
             await this.startAndroidSession(caps);
             break;
@@ -257,32 +258,26 @@ class YouiEngineDriver extends BaseDriver {
     return true;
   }
 
-  async setupNewIOSDriver (caps) {
-    let iosArgs = {
+  async setupNewXCUITestDriver (caps) {
+    let args = {
       javascriptEnabled: true,
     };
 
-    let iosdriver = new XCUITestDriver(iosArgs);
-    // If iOS version is 10 or above we need to use XCUITestDriver (and Xcode 8+)
-    if (caps.platformVersion) {
-      let majorVer = caps.platformVersion.toString().split('.')[0];
-      if (parseInt(majorVer, 10) < 10) {
-        iosdriver = new IOSDriver(iosArgs);
-      }
-    }
+    let driver = new XCUITestDriver(args);
+
     let capsCopy = _.cloneDeep(caps);
     // Disabling the proxy CommandTimeout in the iOS driver since we are now handling it in the YouiEngine Driver
     capsCopy.newCommandTimeout = 0;
-    await iosdriver.createSession(capsCopy);
+    await driver.createSession(capsCopy);
 
-    return iosdriver;
+    return driver;
   }
 
-  async startIOSSession (caps) {
+  async startXCUITestSession (caps) {
     logger.info('Starting an IOS proxy session');
     this.proxyAllowList = TO_PROXY_IOS;
 
-    this.proxydriver = await this.setupNewIOSDriver(caps);
+    this.proxydriver = await this.setupNewXCUITestDriver(caps);
   }
 
   async setupNewAndroidDriver (caps) {


### PR DESCRIPTION
- The youiengine driver now calls the XCUITest driver to deploy and run tvos apps so we can enable the autoAcceptAlert capability