### PR TITLE
feat: proxy 'mobile:shell' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Notes:
 | Command	                 |   Description                                                             |	Argument       |	Argument Example           |
 |----------------------------|---------------------------------------------------------------------------|-----------------|-------------------------------|
 | mobile:pressButton         |   Press a physical button. The available button options can be found [here](https://github.com/YOU-i-Labs/appium-youiengine-driver/blob/master/doc/mobileCommands.md#supported-buttons) |	{name}         |	{name: "Gamepad0"}             |
+| mobile:shell               |   Execute [ADB shell](https://developer.android.com/studio/command-line/adb#shellcommands) commands (requires [insecure feature](http://appium.io/docs/en/writing-running-appium/security/index.html) `adb_shell` to be enabled) | Read this [page](http://appium.io/docs/en/writing-running-appium/android/android-shell/index.html)   |	{'command': 'echo', 'args': ['arg1', 'arg2']} |
 
 [Mobile Commands Example](http://appium.io/docs/en/commands/mobile-command/)
 

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -25,13 +25,25 @@ extensions.execute = async function execute (script, args) {
 extensions.executeMobile = async function executeMobile (mobileCommand, opts = {}) {
   const mobileCommandsMapping = {
     pressButton: 'mobilePressButton',
+    shell: 'mobileShell',
   };
 
   if (!_.has(mobileCommandsMapping, mobileCommand)) {
     throw new errors.UnknownCommandError(`Unknown mobile command "${mobileCommand}". ` +
       `Only ${_.keys(mobileCommandsMapping)} commands are supported.`);
   }
-  return await this[mobileCommandsMapping[mobileCommand]](opts);
+
+  const command = mobileCommandsMapping[mobileCommand];
+
+  if (this[command]) {
+    return await this[command](opts);
+  }
+
+  if (this.proxydriver && this.proxydriver[command]) {
+    return await this.proxydriver[command](opts);
+  }
+
+  throw new errors.UnknownCommandError(`Unknown mobile command "${mobileCommand}"`);
 };
 
 export default extensions;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -285,6 +285,8 @@ class YouiEngineDriver extends BaseDriver {
       javascriptEnabled: true
     };
     let androiddriver = new AndroidDriver(androidArgs);
+    this.setSecurityOptions(androiddriver);
+
     let capsCopy = _.cloneDeep(caps);
     // Disabling the proxy CommandTimeout in the Android driver since we are now handling it in the YouiEngine Driver
     capsCopy.newCommandTimeout = 0;
@@ -320,6 +322,20 @@ class YouiEngineDriver extends BaseDriver {
     this.proxyAllowList = TO_PROXY_MAC;
 
     this.proxydriver = await this.setupNewMacDriver(caps);
+  }
+
+  setSecurityOptions (driver) {
+    if (this.relaxedSecurityEnabled) {
+      driver.relaxedSecurityEnabled = this.relaxedSecurityEnabled;
+    }
+
+    if (this.denyInsecure) {
+      driver.denyInsecure = this.denyInsecure;
+    }
+
+    if (this.allowInsecure) {
+      driver.allowInsecure = this.allowInsecure;
+    }
   }
 
   // SOCKETS


### PR DESCRIPTION
I need to execute several ADB commands, but unfortunately `mobile: shell` is not supported by` appium-youiengine-driver`, so I open this PR to suggest adding support for it.

Let me know if anything needs to be added/changed