### PR TITLE
feat: Add dependabot integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
-  commit_message:
+  commit-message:
     prefix: "chore"
-    include_scope: true
+    include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  commit_message:
+    prefix: "chore"
+    include_scope: true


### PR DESCRIPTION
The module currently contains a couple of outdated dependencies. It makes sense to keep all dependencies at their recent versions because of security and functionality concerns.