### PR TITLE
feat: ability to switch between NATIVE_APP/YOUI_APP context

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Notes:
 | [Touch Up](http://appium.io/docs/en/commands/interactions/touch/touch-up/) | 4.2.7+	|
 | [Update Device Settings](http://appium.io/docs/en/commands/session/settings/update-settings/) | 4.4.5+	|
 | [Element Screenshot](https://webdriver.io/docs/api/element/saveScreenshot.html) | 5.18.0+	|
+| [Set Current Context](http://appium.io/docs/en/commands/context/set-context/) | any	|
 
 
 <sup>1</sup> See [Mobile commands](https://github.com/YOU-i-Labs/appium-youiengine-driver#selector-strategies) below
@@ -288,3 +289,19 @@ Examples (Ruby):
 | `class name`                   |
 | `accessibility id`             |
 <sup>1</sup> Starting with 5.0, `id` selector can be used to search for React Native testID.
+
+### Automating Hybrid Apps
+
+To support hybrid application automation, we added a context called `YOUI_APP` that represents the current driver
+and another context called `NATIVE_APP` which represents the driver used under the hood
+
+> Attention ❗: In case a deeper context than `NATIVE_APP` is used and then you want to continue with `YOUI_APP`,
+> make sure you switch back to `NATIVE_APP` first and only then to `YOUI_APP`
+>
+> Example: `YOUI_APP` -> `NATIVE_APP` -> `WEBVIEW_1` -> `NATIVE_APP` -> `YOUI_APP`
+
+| Platform Name  |                               Appium Driver                                         |
+|----------------|-------------------------------------------------------------------------------------|
+| `ios`, `tvos`  | [appium-xcuitest-driver](https://github.com/appium/appium-xcuitest-driver)          |
+| `android`      | [appium-uiautomator2-driver](https://github.com/appium/appium-uiautomator2-driver)  |
+| `mac`          | [appium-mac-driver](https://github.com/appium/appium-mac-driver)                    |

--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ Notes:
 | [Touch Up](http://appium.io/docs/en/commands/interactions/touch/touch-up/) | 4.2.7+	|
 | [Update Device Settings](http://appium.io/docs/en/commands/session/settings/update-settings/) | 4.4.5+	|
 | [Element Screenshot](https://webdriver.io/docs/api/element/saveScreenshot.html) | 5.18.0+	|
-| [Set Current Context](http://appium.io/docs/en/commands/context/set-context/) | any	|
+| [Get Context](http://appium.io/docs/en/commands/context/get-context/) | any |
+| [Get All Contexts](http://appium.io/docs/en/commands/context/get-contexts/) | any |
+| [Set Current Context](http://appium.io/docs/en/commands/context/set-context/) | any |
 
 
 <sup>1</sup> See [Mobile commands](https://github.com/YOU-i-Labs/appium-youiengine-driver#selector-strategies) below

--- a/README.md
+++ b/README.md
@@ -299,8 +299,6 @@ and another context called `NATIVE_APP` which represents the driver used under t
 
 > Attention ❗: In case a deeper context than `NATIVE_APP` is used and then you want to continue with `YOUI_APP`,
 > make sure you switch back to `NATIVE_APP` first and only then to `YOUI_APP`
->
-> Example: `YOUI_APP` -> `NATIVE_APP` -> `WEBVIEW_1` -> `NATIVE_APP` -> `YOUI_APP`
 
 | Platform Name  |                               Appium Driver                                         |
 |----------------|-------------------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -290,9 +290,9 @@ Examples (Ruby):
 | `accessibility id`             |
 <sup>1</sup> Starting with 5.0, `id` selector can be used to search for React Native testID.
 
-### Automating Hybrid Apps
+## Hybrid Apps
 
-To support hybrid application automation, we added a context called `YOUI_APP` that represents the current driver
+To support [hybrid application](http://appium.io/docs/en/writing-running-appium/web/hybrid/index.html) automation, we added a context called `YOUI_APP` that represents the current driver
 and another context called `NATIVE_APP` which represents the driver used under the hood
 
 > Attention ❗: In case a deeper context than `NATIVE_APP` is used and then you want to continue with `YOUI_APP`,

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -13,8 +13,11 @@ commands.getCurrentContext = async function () { // eslint-disable-line require-
 };
 
 commands.getContexts = async function () { // eslint-disable-line require-await
-  this.contexts = [YOUI_APP, NATIVE_APP];
-  return this.contexts;
+  if (this.proxydriver) {
+    return [YOUI_APP, NATIVE_APP];
+  } else {
+    return [YOUI_APP];
+  }
 };
 
 commands.setContext = function (context) {

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -21,10 +21,6 @@ commands.getContexts = async function () { // eslint-disable-line require-await
 };
 
 commands.setContext = function (context) {
-  if (!this.proxydriver) {
-    throw new errors.NotImplementedError();
-  }
-
   switch (context) {
     case YOUI_APP:
       this.proxyAll = false;

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -1,17 +1,37 @@
+import { errors } from 'appium-base-driver';
+
 let commands = {};
 
-const NATIVE_WIN = 'NATIVE_APP';
+const YOUI_APP = 'YOUI_APP';
+const NATIVE_APP = 'NATIVE_APP';
 
 /* -------------------------------
  * Actual MJSONWP command handlers
  * ------------------------------- */
 commands.getCurrentContext = async function () { // eslint-disable-line require-await
-  return NATIVE_WIN;
+  return YOUI_APP;
 };
 
 commands.getContexts = async function () { // eslint-disable-line require-await
-  this.contexts = [NATIVE_WIN];
+  this.contexts = [YOUI_APP, NATIVE_APP];
   return this.contexts;
+};
+
+commands.setContext = function (context) {
+  if (!this.proxydriver) {
+    throw new errors.NotImplementedError();
+  }
+
+  switch (context) {
+    case YOUI_APP:
+      this.proxyAll = false;
+      break;
+    case NATIVE_APP:
+      this.proxyAll = true;
+      break;
+    default:
+      throw new errors.NoSuchContextError();
+  }
 };
 
 export default commands;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -199,24 +199,16 @@ class YouiEngineDriver extends BaseDriver {
       return await this.receiveAsyncResponse(...args);
     }
 
-    if (this.proxydriver && cmd === 'setContext') {
-      let context = args[0];
-
-      if (context === 'YOUI_APP') {
-        this.proxyAll = false;
-        return;
-      }
-
-      if (context === 'NATIVE_APP' && !this.proxyAll) {
-        this.proxyAll = true;
-        return;
-      }
-    }
-
     if (this.ready) {
 
       if (this.driverShouldDoProxyCmd(cmd)) {
         logger.debug(`Executing proxied WebDriver command '${cmd}'`);
+
+        // Manually handle our own YOUI_APP context
+        if (cmd === 'setContext' && args[0] === 'YOUI_APP') {
+          this.proxyAll = false;
+          return await this.executeCommand(cmd, ...args);
+        }
 
         // There are 2 CommandTimeout (YouiEngineDriver and proxy)
         // Only YouiEngineDriver CommandTimeout is used; Proxy is disabled

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -201,10 +201,13 @@ class YouiEngineDriver extends BaseDriver {
 
     if (this.proxydriver && cmd === 'setContext') {
       let context = args[0];
+
       if (context === 'YOUI_APP') {
         this.proxyAll = false;
         return;
-      } else if (context === 'NATIVE_APP' && !this.proxyAll) {
+      }
+
+      if (context === 'NATIVE_APP' && !this.proxyAll) {
         this.proxyAll = true;
         return;
       }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -63,6 +63,7 @@ class YouiEngineDriver extends BaseDriver {
     this.locatorStrategies = ['id', 'name', 'class name', 'accessibility id'];
     this.proxydriver = null;
     this.proxyAllowList = '';
+    this.proxyAll = false;
     this.device = null;
   }
 
@@ -179,6 +180,10 @@ class YouiEngineDriver extends BaseDriver {
       return false;
     }
 
+    if (this.proxyAll) {
+      return true;
+    }
+
     // only allow white listed commands
     for (let allowedCommand of this.proxyAllowList) {
       if (allowedCommand === command) {
@@ -192,7 +197,20 @@ class YouiEngineDriver extends BaseDriver {
     if (cmd === 'receiveAsyncResponse') {
       logger.debug(`Executing YouiEngineDriver response '${cmd}'`);
       return await this.receiveAsyncResponse(...args);
-    } else if (this.ready) {
+    }
+
+    if (this.proxydriver && cmd === 'setContext') {
+      let context = args[0];
+      if (context === 'YOUI_APP') {
+        this.proxyAll = false;
+        return;
+      } else if (context === 'NATIVE_APP' && !this.proxyAll) {
+        this.proxyAll = true;
+        return;
+      }
+    }
+
+    if (this.ready) {
 
       if (this.driverShouldDoProxyCmd(cmd)) {
         logger.debug(`Executing proxied WebDriver command '${cmd}'`);


### PR DESCRIPTION
Hi, I want to suggest a feature that will unblock automation of scenarios that requires interaction with native elements (without an extra session) by adding a context called `YOUI_APP` and the ability to switch between `NATIVE_APP`/`YOUI_APP` in a way similar to which Appium uses for [hybrid apps](http://appium.io/docs/en/writing-running-appium/web/hybrid/) automation.


```kotlin
// do something in you.i based app
// ...

driver.context("NATIVE_APP")
// working with native elements
// ...

driver.context("YOUI_APP")
// continue with you.i based app
// ...
```

<hr>

**UPDATE:** this PR should help with #141 too
```kotlin
driver.context("NATIVE_APP") // switch to uiautomator2/xcuitest
driver.context("WEBVIEW_1")  // switch in first webview
```