### PR TITLE
adding default opts along with args while creating xcuitest driver

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -261,6 +261,7 @@ class YouiEngineDriver extends BaseDriver {
     let args = {
       javascriptEnabled: true,
     };
+    args = Object.assign(this.opts, args);
 
     let driver = new XCUITestDriver(args);
 


### PR DESCRIPTION
Fix for: https://github.com/YOU-i-Labs/appium-youiengine-driver/issues/144

Adding opts to args while creating XCUITestDriver,  to honor default args being passed in `this.opts`