### PR TITLE
feat: add `appium` entry in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,23 @@
   "engines": [
     "node"
   ],
+  "appium": {
+    "driverName": "YouiEngine",
+    "automationName": "YouiEngine",
+    "platformNames": [
+      "ios",
+      "tvos",
+      "android",
+      "mac",
+      "yimac",
+      "yilinux",
+      "bluesky",
+      "yitvos",
+      "noproxy",
+      "connecttoapp"
+    ],
+    "mainClass": "YouiEngineDriver"
+  },
   "main": "./build/index.js",
   "bin": {},
   "directories": {


### PR DESCRIPTION
Hi, I want to propose a small change in `package.json` that will make that driver compatible with the new appium server

---
Other standard drivers already include that section:
- appium-xcuitest-driver: [package.json#L24](https://github.com/appium/appium-xcuitest-driver/blob/master/package.json#L24)
- appium-uiautomator2-driver: [package.json#L23](https://github.com/appium/appium-uiautomator2-driver/blob/master/package.json#L23)
- ...