### PR TITLE
Fix: null checks for deleteSession method

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -167,7 +167,7 @@ class YouiEngineDriver extends BaseDriver {
   async deleteSession () {
     logger.debug('Deleting YouiEngine session');
 
-    if (this.caps.platformName !== null) {
+    if (this.caps?.platformName) {
       let appPlatform = this.caps.platformName.toLowerCase();
 
       if (['yimac', 'yitvos', 'bluesky', 'yilinux'].includes(appPlatform)) {
@@ -180,8 +180,8 @@ class YouiEngineDriver extends BaseDriver {
     if (this.proxydriver !== null) {
       await this.proxydriver.deleteSession();
     }
-    this.socket.end();
-    this.socket.destroy();
+    this.socket?.end();
+    this.socket?.destroy();
     await super.deleteSession();
     await this.stop();
   }


### PR DESCRIPTION
Hi. This small pr fix problem when driver is not able to create a session and call deleteSession method. In this case we have 
"this.caps" is null and "this.caps.platformName" is undefined.

For example, we have the wrong app path and in appium and session is not created with the error 'The app could not be found in following location: '
After that is called deleteSession method where capabilities is null. 
So, finally, instead of an error message in the client, I can see only error message "org.openqa.selenium.SessionNotCreatedException: Unable to create a new remote session. Please check the server log for more details. Original error: An unknown server-side error occurred while processing the command. Original error: Cannot read property 'platformName' of null"

and the same problems with "end of null" and "destroy of null"