### PR TITLE
avd optional for android real device

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -280,7 +280,9 @@ class YouiEngineDriver extends BaseDriver {
 
       //Android emulator with proxy
       if (caps.deviceName.toLowerCase() === 'android') {
-        if (!caps.avd) {
+
+        // avd is only required with emulator, which runs on localhost
+        if (!caps.avd && caps.youiEngineAppAddress === 'localhost') {
           let msg = 'The desired capabilities must include avd';
           logger.errorAndThrow(msg);
         }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "appium"
   ],
-  "version": "1.2.9",
+  "version": "1.2.10",
   "author": "youi.tv",
   "license": "Apache-2.0",
   "repository": {

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -156,16 +156,29 @@ describe('driver', function () {
         driver.validateDesiredCaps({automationName: 'YouiEngine', platformName: 'NoProxy', deviceName: 'Android' });
       }).to.not.throw(/must include/);
     });
-    /*it('should not throw an error for minimum caps of Android emulator', () => {
+
+    it('should not throw an error for minimum caps of Android emulator', function () {
       expect(() => {
         driver.validateDesiredCaps({automationName: 'YouiEngine', platformName: 'Android', deviceName: 'Android', youiEngineAppAddress: 'localhost', app: '/path/to/some.app', avd: 'Nexus' });
       }).to.not.throw(Error);
-    });*/
+    });
+
+    it('should throw an error if caps dos not contain avd for Android emulator', function () {
+      expect(() => {
+        driver.validateDesiredCaps({automationName: 'YouiEngine', platformName: 'Android', deviceName: 'Android', youiEngineAppAddress: 'localhost', app: '/path/to/some.app' });
+      }).to.throw(Error);
+    });
 
     // 4) Android real device
     it('should not throw an error for minimum caps of Android real device', function () {
       expect(() => {
         driver.validateDesiredCaps({automationName: 'YouiEngine', platformName: 'Android', deviceName: '83B7N14B02224534', youiEngineAppAddress: '192.168.1.72', app: '/path/to/some.app', avd: 'Nexus' });
+      }).to.not.throw(Error);
+    });
+
+    it('should not throw an error if caps dos not contain avd for Android real device', function () {
+      expect(() => {
+        driver.validateDesiredCaps({automationName: 'YouiEngine', platformName: 'Android', deviceName: 'Android', youiEngineAppAddress: '192.168.1.72', app: '/path/to/some.app' });
       }).to.not.throw(Error);
     });
 


### PR DESCRIPTION
Making `avd` optional in device capability validation for Android since avd (Android Virtual Device) only makes sense when running You.I application on Android emulator.

Changes:
1. the driver throw only if `avd` is missing for Android Emulator (when `youiEngineAppAddress1 ` is set to`localhost`).
2. added unit tests for it.
3. version number bumps to `1.2.10`.